### PR TITLE
Fix account retrieval typo

### DIFF
--- a/frontend/src/components/OwnedObjects.tsx
+++ b/frontend/src/components/OwnedObjects.tsx
@@ -20,7 +20,7 @@ export const OwnedObjects = () => {
     }
   );
 
-  if (!account) return "Cannot retreive account";
+  if (!account) return "Cannot retrieve account";
   if (error) return <div className="text-red-500">Error: {error.message}</div>;
   if (isPending || !response) return <div className="text-center text-gray-500">Loading...</div>;
 


### PR DESCRIPTION
## Summary
- correct a typo in the account retrieval message in `OwnedObjects.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68521eecfc048320996638d07792eb98