### PR TITLE
Fix navigation provider effect

### DIFF
--- a/frontend/src/providers/navigation/NavigationProvider.tsx
+++ b/frontend/src/providers/navigation/NavigationProvider.tsx
@@ -20,7 +20,7 @@ const NavigationProvider: React.FC<NavigationProps> = ({children}) => {
 
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
-  });
+  }, []);
 
   return (
     <NavigationContext.Provider value={{currentPage, navigate}}>


### PR DESCRIPTION
## Summary
- avoid re-registering popstate listener on every render

## Testing
- `npm run lint`
- `npm run build` *(fails: Transaction type mismatch in VoteModal.tsx)*
- `npm run dev:test`

------
https://chatgpt.com/codex/tasks/task_e_68521f897eb48320a67bce8c58658da7