### PR TITLE
Fix typo in vote proof

### DIFF
--- a/contracts/voting_system/sources/proposal.move
+++ b/contracts/voting_system/sources/proposal.move
@@ -184,7 +184,7 @@ fun issue_vote_proof(proposal: &Proposal, vote_yes: bool, ctx: &mut TxContext) {
     let mut name = b"NFT ".to_string();
     name.append(proposal.title);
 
-    let mut description = b"Proof of votting on ".to_string();
+    let mut description = b"Proof of voting on ".to_string();
     let proposal_address = object::id_address(proposal).to_string();
     description.append(proposal_address);
 


### PR DESCRIPTION
## Summary
- fix a minor typo in `proposal.move`

## Testing
- `npm test` *(fails: Missing script)*
- `sui move test` *(fails: `sui` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522597b94483208ad68879a57c7423